### PR TITLE
Fix application errors

### DIFF
--- a/DebtNet/DebtListView.swift
+++ b/DebtNet/DebtListView.swift
@@ -218,12 +218,12 @@ struct DebtListView: View {
         .gesture(
             DragGesture()
                 .onChanged { value in
-                    if value.translation.y > 0 && !archivedDebts.isEmpty {
-                        dragOffset = value.translation.y
+                    if value.translation.height > 0 && !archivedDebts.isEmpty {
+                        dragOffset = value.translation.height
                     }
                 }
                 .onEnded { value in
-                    if value.translation.y > 100 && !archivedDebts.isEmpty {
+                    if value.translation.height > 100 && !archivedDebts.isEmpty {
                         withAnimation(.easeInOut(duration: 0.3)) {
                             showingArchive = true
                         }


### PR DESCRIPTION
Fix 'CGSize has no member y' compiler error by using `height` for `DragGesture` translation.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-74d324e8-5199-424f-a1ac-868d02f11cb4) · [Cursor](https://cursor.com/background-agent?bcId=bc-74d324e8-5199-424f-a1ac-868d02f11cb4)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)