### PR TITLE
Fix codebase issue

### DIFF
--- a/DebtNet/DebtListView.swift
+++ b/DebtNet/DebtListView.swift
@@ -390,7 +390,7 @@ struct DebtHistoryRowView: View {
             if debt.interestRate > 0 {
                 Text(debt.amountWithInterestAndSign)
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor((debt.type == .owedToMe ? .green : .red).opacity(0.8))
+                    .foregroundColor((debt.type == .owedToMe ? Color.green : Color.red).opacity(0.8))
                 
                 Text("\(String(format: "%.1f", debt.interestRate))%")
                     .font(.system(size: 10))


### PR DESCRIPTION
Qualify color references with `Color` to fix a Swift compiler error.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-3706877b-9aa3-4488-9255-3537689ee818) · [Cursor](https://cursor.com/background-agent?bcId=bc-3706877b-9aa3-4488-9255-3537689ee818)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)