### PR TITLE
Выровнять размеры окон

### DIFF
--- a/DebtNet/StatisticsView.swift
+++ b/DebtNet/StatisticsView.swift
@@ -113,13 +113,17 @@ struct StatCard: View {
                 .font(.system(size: 14))
                 .foregroundColor(.white.opacity(0.7))
                 .multilineTextAlignment(.leading)
+                .lineLimit(2)
+                .fixedSize(horizontal: false, vertical: true)
+            
+            Spacer()
             
             Text(formattedValue)
                 .font(.system(size: 20, weight: .bold))
                 .foregroundColor(color)
         }
         .padding()
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity, minHeight: 100, maxHeight: 100, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 12)
                 .fill(Color.gray.opacity(0.1))


### PR DESCRIPTION
Standardize `StatCard` dimensions to ensure uniform display regardless of content.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-f24c556c-ca43-495a-beac-c1181ac41665) · [Cursor](https://cursor.com/background-agent?bcId=bc-f24c556c-ca43-495a-beac-c1181ac41665)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)