### PR TITLE
Убрать процентную строку из окна

### DIFF
--- a/DebtNet/DebtListView.swift
+++ b/DebtNet/DebtListView.swift
@@ -138,15 +138,9 @@ struct DebtListView: View {
                 .font(.system(size: 20, weight: .bold))
                 .foregroundColor(.green)
             
-            if debtStore.totalOwedToMeWithInterest != debtStore.totalOwedToMe {
-                Text("С %: \(Int(debtStore.totalOwedToMeWithInterest)) ₽")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(.green.opacity(0.8))
-            } else {
-                // Add spacing to match the other card height
-                Text(" ")
-                    .font(.system(size: 16, weight: .semibold))
-            }
+            // Removed interest percentage display
+            Text(" ")
+                .font(.system(size: 16, weight: .semibold))
         }
         .frame(maxWidth: .infinity, minHeight: 80, alignment: .leading)
         .padding()


### PR DESCRIPTION
Remove the interest percentage line from the 'Owed to me' card.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-2b618b5d-1819-46c6-8970-16b0a40e679b) · [Cursor](https://cursor.com/background-agent?bcId=bc-2b618b5d-1819-46c6-8970-16b0a40e679b)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)