### PR TITLE
Fix codebase issue

### DIFF
--- a/DebtNet.xcodeproj/project.pbxproj
+++ b/DebtNet.xcodeproj/project.pbxproj
@@ -19,6 +19,9 @@
 		3D7B3A402B5F1C7000123456 /* StatisticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7B3A3F2B5F1C7000123456 /* StatisticsView.swift */; };
 		3D7B3A422B5F1C8000123456 /* DebtDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7B3A412B5F1C8000123456 /* DebtDetailView.swift */; };
 		3D7B3A442B5F1C9000123456 /* EditDebtView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7B3A432B5F1C9000123456 /* EditDebtView.swift */; };
+		3D7B3A462B5F1CB000123456 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7B3A452B5F1CB000123456 /* NotificationManager.swift */; };
+		3D7B3A482B5F1CC000123456 /* NotificationSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7B3A472B5F1CC000123456 /* NotificationSettingsView.swift */; };
+		3D7B3A4A2B5F1CD000123456 /* NotificationTestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7B3A492B5F1CD000123456 /* NotificationTestHelper.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -35,6 +38,9 @@
 		3D7B3A3F2B5F1C7000123456 /* StatisticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsView.swift; sourceTree = "<group>"; };
 		3D7B3A412B5F1C8000123456 /* DebtDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebtDetailView.swift; sourceTree = "<group>"; };
 		3D7B3A432B5F1C9000123456 /* EditDebtView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditDebtView.swift; sourceTree = "<group>"; };
+		3D7B3A452B5F1CB000123456 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
+		3D7B3A472B5F1CC000123456 /* NotificationSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSettingsView.swift; sourceTree = "<group>"; };
+		3D7B3A492B5F1CD000123456 /* NotificationTestHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTestHelper.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,6 +83,9 @@
 				3D7B3A3F2B5F1C7000123456 /* StatisticsView.swift */,
 				3D7B3A412B5F1C8000123456 /* DebtDetailView.swift */,
 				3D7B3A432B5F1C9000123456 /* EditDebtView.swift */,
+				3D7B3A452B5F1CB000123456 /* NotificationManager.swift */,
+				3D7B3A472B5F1CC000123456 /* NotificationSettingsView.swift */,
+				3D7B3A492B5F1CD000123456 /* NotificationTestHelper.swift */,
 				3D7B3A2D2B5F1C2100123456 /* Assets.xcassets */,
 				3D7B3A2F2B5F1C2100123456 /* Preview Content */,
 			);
@@ -171,6 +180,9 @@
 				3D7B3A2A2B5F1C2000123456 /* DebtNetApp.swift in Sources */,
 				3D7B3A422B5F1C8000123456 /* DebtDetailView.swift in Sources */,
 				3D7B3A442B5F1C9000123456 /* EditDebtView.swift in Sources */,
+				3D7B3A462B5F1CB000123456 /* NotificationManager.swift in Sources */,
+				3D7B3A482B5F1CC000123456 /* NotificationSettingsView.swift in Sources */,
+				3D7B3A4A2B5F1CD000123456 /* NotificationTestHelper.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Integrate missing Notification-related Swift files into the Xcode project to resolve build errors.

The `NotificationManager.swift`, `NotificationSettingsView.swift`, and `NotificationTestHelper.swift` files were present in the file system but not properly included in the project's build phases, leading to 'Cannot find in scope' compilation errors.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-0c0e7892-953c-4522-827b-78535a1621f3) · [Cursor](https://cursor.com/background-agent?bcId=bc-0c0e7892-953c-4522-827b-78535a1621f3)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)