### PR TITLE
Нейтрализовать цвет кнопки редактирования

### DIFF
--- a/DebtNet/DebtDetailView.swift
+++ b/DebtNet/DebtDetailView.swift
@@ -92,7 +92,7 @@ struct DebtDetailView: View {
                     showingEditDebt = true
                 }) {
                     Image(systemName: "pencil")
-                        .foregroundColor(.black)
+                        .foregroundColor(Color(.systemGray))
                         .font(.title2)
                 }
             }


### PR DESCRIPTION
Change edit button color to system gray for a neutral yet visible appearance.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-4a61e6da-b8e2-4cb2-ad5a-1165ceb564db) · [Cursor](https://cursor.com/background-agent?bcId=bc-4a61e6da-b8e2-4cb2-ad5a-1165ceb564db)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)