### PR TITLE
Изменить иконку на часы 21:00

### DIFF
--- a/DebtNet/ContentView.swift
+++ b/DebtNet/ContentView.swift
@@ -47,7 +47,7 @@ struct ContentView: View {
                         selectedTab = 1
                     }) {
                         VStack(spacing: 4) {
-                            Image(systemName: "chart.bar.fill")
+                            Image(systemName: "clock.fill")
                                 .font(.system(size: 20))
                                 .foregroundColor(selectedTab == 1 ? .blue : .gray)
                             


### PR DESCRIPTION
Change 'History' tab icon from `chart.bar.fill` to `clock.fill` to represent time.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-1e16a2d3-70ae-45bd-9418-bdbe135dad2b) · [Cursor](https://cursor.com/background-agent?bcId=bc-1e16a2d3-70ae-45bd-9418-bdbe135dad2b)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)