### PR TITLE
Сдвинуть надпись настройки влево

### DIFF
--- a/DebtNet/ContentView.swift
+++ b/DebtNet/ContentView.swift
@@ -99,12 +99,16 @@ struct SettingsView: View {
             
             VStack(spacing: 0) {
                 // Header
-                Text("Настройки")
-                    .font(.title)
-                    .fontWeight(.bold)
-                    .foregroundColor(themeManager.primaryTextColor)
-                    .padding(.top, 20)
-                    .padding(.bottom, 30)
+                HStack {
+                    Text("Настройки")
+                        .font(.title)
+                        .fontWeight(.bold)
+                        .foregroundColor(themeManager.primaryTextColor)
+                    Spacer()
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 20)
+                .padding(.bottom, 30)
                 
                 // Settings Content
                 VStack(spacing: 16) {


### PR DESCRIPTION
Align 'Настройки' (Settings) title to the left edge of the screen as requested.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-61aac89d-3c9b-45e9-b080-5e042f8c46a1) · [Cursor](https://cursor.com/background-agent?bcId=bc-61aac89d-3c9b-45e9-b080-5e042f8c46a1)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)