### PR TITLE
Вернуть красный круг

### DIFF
--- a/DebtNet/DebtListView.swift
+++ b/DebtNet/DebtListView.swift
@@ -131,8 +131,7 @@ struct DebtListView: View {
                     .foregroundColor(.black)
                     .font(.title2)
                     .frame(width: 40, height: 40)
-                    .background(Circle().fill(Color.black.opacity(0.8)))
-                    .foregroundColor(.red)
+                    .background(Circle().fill(Color.red))
             }
         }
         .padding(.horizontal)


### PR DESCRIPTION
Restore the add button's red circle background and fix conflicting styling.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-7611967d-ca6e-4212-8c9e-d937ad0cde0d) · [Cursor](https://cursor.com/background-agent?bcId=bc-7611967d-ca6e-4212-8c9e-d937ad0cde0d)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)