### PR TITLE
Сделать кнопку с галочкой темнее

### DIFF
--- a/DebtNet/DebtDetailView.swift
+++ b/DebtNet/DebtDetailView.swift
@@ -101,10 +101,10 @@ struct DebtDetailView: View {
             if debt.isPaid {
                 HStack {
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
+                        .foregroundColor(Color(red: 0.0, green: 0.6, blue: 0.0))
                     Text("ПОГАШЕН")
                         .font(.system(size: 14, weight: .bold))
-                        .foregroundColor(.green)
+                        .foregroundColor(Color(red: 0.0, green: 0.6, blue: 0.0))
                 }
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)

--- a/DebtNet/DebtListView.swift
+++ b/DebtNet/DebtListView.swift
@@ -464,12 +464,12 @@ struct DebtHistoryRowView: View {
                 }
             }
             
-            // Status icon
+            // Status icon - darker green for better visibility
             Button(action: {
                 showingStatusChangeAlert = true
             }) {
                 Image(systemName: "checkmark.circle.fill")
-                    .foregroundColor(.green)
+                    .foregroundColor(Color(red: 0.0, green: 0.6, blue: 0.0))
                     .font(.system(size: 24))
                     .background(
                         Circle()
@@ -635,12 +635,12 @@ struct ArchivedDebtRowView: View {
                 
                 Text("ПОГАШЕН")
                     .font(.system(size: 10, weight: .bold))
-                    .foregroundColor(.green)
+                    .foregroundColor(Color(red: 0.0, green: 0.6, blue: 0.0))
                     .padding(.horizontal, 6)
                     .padding(.vertical, 2)
                     .background(
                         RoundedRectangle(cornerRadius: 4)
-                            .fill(Color.green.opacity(0.2))
+                            .fill(Color(red: 0.0, green: 0.6, blue: 0.0).opacity(0.2))
                     )
             }
             

--- a/DebtNet/StatisticsView.swift
+++ b/DebtNet/StatisticsView.swift
@@ -459,7 +459,7 @@ struct RecentActivityRow: View {
             HStack {
                 if debt.isPaid {
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
+                        .foregroundColor(Color(red: 0.0, green: 0.6, blue: 0.0))
                 }
                 
                 Text(debt.formattedAmount)


### PR DESCRIPTION
Make checkmark icons and "ПОГАШЕН" (PAID) indicators darker for improved visibility.

The default bright green was too light, so a custom darker green `Color(red: 0.0, green: 0.6, blue: 0.0)` was applied to enhance contrast and readability across the application, as per user request.

---
<a href="https://cursor.com/background-agent?bcId=bc-797a94b7-dbfe-4204-850d-7330e86efa32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-797a94b7-dbfe-4204-850d-7330e86efa32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>