### PR TITLE
Отключить свайп для закрытия долгов на главном экране

### DIFF
--- a/DebtNet/DebtListView.swift
+++ b/DebtNet/DebtListView.swift
@@ -259,13 +259,6 @@ struct DebtListView: View {
                                 Label("Удалить", systemImage: "trash")
                             }
                             .tint(.red)
-                            
-                            Button {
-                                debtStore.togglePaidStatus(debt)
-                            } label: {
-                                Label("Оплачено", systemImage: "checkmark")
-                            }
-                            .tint(.green)
                         }
                 }
                 
@@ -555,14 +548,8 @@ struct DebtHistoryRowView: View {
                         showingDeleteButton = swipeOffset < -50
                         showingPayButton = false
                     }
-                } else if translation > 0 {
-                    // Swiping right - show pay button
-                    withAnimation(.easeOut(duration: 0.1)) {
-                        swipeOffset = min(translation, 100)
-                        showingPayButton = swipeOffset > 50
-                        showingDeleteButton = false
-                    }
                 }
+                // Removed swipe right functionality for paying debt
             }
             .onEnded { value in
                 let translation = value.translation.width
@@ -573,11 +560,6 @@ struct DebtHistoryRowView: View {
                         swipeOffset = -100
                         showingDeleteButton = true
                         showingPayButton = false
-                    } else if translation > 80 {
-                        // If swiped right far enough, show pay button
-                        swipeOffset = 100
-                        showingPayButton = true
-                        showingDeleteButton = false
                     } else {
                         // Snap back to original position
                         swipeOffset = 0
@@ -592,9 +574,6 @@ struct DebtHistoryRowView: View {
         ZStack {
             // Background actions
             HStack {
-                if showingPayButton {
-                    payButton
-                }
                 Spacer()
                 if showingDeleteButton {
                     deleteButton


### PR DESCRIPTION
Remove swipe-right gesture for paying off debts.

---
<a href="https://cursor.com/background-agent?bcId=bc-c26ed9cd-a610-41be-96e5-5dccabff5457">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c26ed9cd-a610-41be-96e5-5dccabff5457">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>