### PR TITLE
Обновить статистику по второму скрину

### DIFF
--- a/DebtNet/StatisticsView.swift
+++ b/DebtNet/StatisticsView.swift
@@ -64,27 +64,30 @@ struct SummaryCardsView: View {
     
     var body: some View {
         VStack(spacing: 18) {
-            // Делаем карточки полной ширины и расположенные вертикально
-            StatCard(
-                title: "Мне должны",
-                value: debtStore.totalOwedToMeWithInterest,
-                color: .green,
-                icon: "arrow.down.circle.fill",
-                isActive: selectedFilter == .owedToMe
-            ) {
-                selectedFilter = selectedFilter == .owedToMe ? .all : .owedToMe
+            // Первый ряд карточек
+            HStack(spacing: 18) {
+                StatCard(
+                    title: "Мне должны",
+                    value: debtStore.totalOwedToMeWithInterest,
+                    color: .green,
+                    icon: "arrow.down.circle.fill",
+                    isActive: selectedFilter == .owedToMe
+                ) {
+                    selectedFilter = selectedFilter == .owedToMe ? .all : .owedToMe
+                }
+                
+                StatCard(
+                    title: "Я должен",
+                    value: debtStore.totalIOwe,
+                    color: .red,
+                    icon: "arrow.up.circle.fill",
+                    isActive: selectedFilter == .iOwe
+                ) {
+                    selectedFilter = selectedFilter == .iOwe ? .all : .iOwe
+                }
             }
             
-            StatCard(
-                title: "Я должен",
-                value: debtStore.totalIOwe,
-                color: .red,
-                icon: "arrow.up.circle.fill",
-                isActive: selectedFilter == .iOwe
-            ) {
-                selectedFilter = selectedFilter == .iOwe ? .all : .iOwe
-            }
-            
+            // Второй ряд карточек  
             HStack(spacing: 18) {
                 StatCard(
                     title: "Активных долгов",
@@ -134,41 +137,51 @@ struct StatCard: View {
     
     var body: some View {
         Button(action: onTap) {
-            HStack(spacing: 16) {
-                // Левая часть с иконкой и текстом
-                HStack(spacing: 12) {
+            VStack(spacing: 12) {
+                // Иконка вверху
+                HStack {
                     Image(systemName: icon)
                         .foregroundColor(isActive ? .white : color)
                         .font(.title2)
-                        .frame(width: 24, height: 24)
+                        .frame(width: 28, height: 28)
                     
-                    Text(title)
-                        .font(.system(size: 17, weight: .semibold))
-                        .foregroundColor(isActive ? .white : (themeManager.isDarkMode ? .white : themeManager.primaryTextColor))
-                        .multilineTextAlignment(.leading)
-                        .lineLimit(2)
+                    Spacer()
                 }
                 
-                Spacer()
-                
-                // Правая часть с суммой
-                Text(formattedValue)
-                    .font(.system(size: 22, weight: .bold, design: .rounded))
-                    .foregroundColor(isActive ? .white : color)
+                // Текст и значение снизу
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text(title)
+                            .font(.system(size: 15, weight: .medium))
+                            .foregroundColor(isActive ? .white : (themeManager.isDarkMode ? .white : themeManager.primaryTextColor))
+                            .multilineTextAlignment(.leading)
+                            .lineLimit(2)
+                        
+                        Spacer()
+                    }
+                    
+                    HStack {
+                        Text(formattedValue)
+                            .font(.system(size: 24, weight: .bold, design: .rounded))
+                            .foregroundColor(isActive ? .white : color)
+                        
+                        Spacer()
+                    }
+                }
             }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 18)
-            .frame(maxWidth: .infinity, minHeight: 68, maxHeight: 68, alignment: .leading)
+            .padding(.horizontal, 18)
+            .padding(.vertical, 20)
+            .frame(maxWidth: .infinity, minHeight: 100, maxHeight: 100, alignment: .topLeading)
             .background(
-                RoundedRectangle(cornerRadius: 12)
+                RoundedRectangle(cornerRadius: 16)
                     .fill(isActive ? color.opacity(0.8) : themeManager.cardBackgroundColor)
-                    .shadow(color: themeManager.shadowColor, radius: 2, x: 0, y: 1)
+                    .shadow(color: themeManager.shadowColor, radius: 4, x: 0, y: 2)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 12)
-                    .stroke(isActive ? color : themeManager.borderColor, lineWidth: isActive ? 2 : 1)
+                RoundedRectangle(cornerRadius: 16)
+                    .stroke(isActive ? color : themeManager.borderColor, lineWidth: isActive ? 2 : 0.5)
             )
-            .scaleEffect(isActive ? 0.98 : 1.0)
+            .scaleEffect(isActive ? 0.95 : 1.0)
             .animation(.easeInOut(duration: 0.2), value: isActive)
         }
         .buttonStyle(PlainButtonStyle())


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Refactor statistics summary cards to a 2x2 grid layout and update card design to match the provided dark theme screenshot.

---
<a href="https://cursor.com/background-agent?bcId=bc-054ae508-d864-4b4a-82bb-1f9b78e74357">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-054ae508-d864-4b4a-82bb-1f9b78e74357">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>