### PR TITLE
Сделать скролл на весь экран на главном экране

### DIFF
--- a/DebtNet/DebtListView.swift
+++ b/DebtNet/DebtListView.swift
@@ -567,7 +567,7 @@ struct DebtHistoryRowView: View {
         .onTapGesture {
             showingDetail = true
         }
-        .gesture(swipeGesture)
+        .simultaneousGesture(swipeGesture)
         .allowsHitTesting(true) // Убеждаемся, что жесты работают правильно
     }
     
@@ -823,7 +823,7 @@ struct ArchivedDebtRowView: View {
         .onTapGesture {
             showingDetail = true
         }
-        .gesture(archivedSwipeGesture)
+        .simultaneousGesture(archivedSwipeGesture)
         .allowsHitTesting(true) // Убеждаемся, что жесты работают правильно
     }
     


### PR DESCRIPTION
Enable full-screen scrolling on the debt list by allowing simultaneous gestures.

Previously, the exclusive `.gesture` on debt rows for swipe-to-delete/settle functionality blocked vertical scrolling if the drag started on a row. Changing to `.simultaneousGesture` allows vertical scrolling to work from any part of the screen, including directly on the list items.

---
<a href="https://cursor.com/background-agent?bcId=bc-48c2e7c3-fdb8-450c-97ce-6f20f22b2f7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-48c2e7c3-fdb8-450c-97ce-6f20f22b2f7f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>