### PR TITLE
Перенести архив погашенных долгов в отдельное окно

### DIFF
--- a/DebtNet/ArchivedDebtsView.swift
+++ b/DebtNet/ArchivedDebtsView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct ArchivedDebtsView: View {
+    @EnvironmentObject var debtStore: DebtStore
+    @EnvironmentObject var themeManager: ThemeManager
+    
+    private var archivedDebts: [Debt] {
+        debtStore.paidDebts.sorted { $0.dateCreated > $1.dateCreated }
+    }
+    
+    var body: some View {
+        ZStack {
+            themeManager.backgroundColor.ignoresSafeArea()
+            
+            if archivedDebts.isEmpty {
+                Text("Нет погашенных долгов")
+                    .foregroundColor(themeManager.secondaryTextColor)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 12) {
+                        ForEach(archivedDebts) { debt in
+                            ArchivedDebtRowView(debt: debt)
+                                .environmentObject(themeManager)
+                                .environmentObject(debtStore)
+                                .padding(.horizontal)
+                        }
+                    }
+                    .padding(.top, 20)
+                }
+            }
+        }
+        .navigationTitle("Архив")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    ArchivedDebtsView()
+        .environmentObject(DebtStore())
+        .environmentObject(ThemeManager())
+}

--- a/DebtNet/DebtListView.swift
+++ b/DebtNet/DebtListView.swift
@@ -69,28 +69,20 @@ struct DebtListView: View {
                     headerView
                     filterButtonsView
                     summaryCardsView
-                    archiveIndicatorView
+                    archiveNavigationLinkView
                 }
                 .padding(.bottom, 20)
                 
                 // Список долгов
                 debtListContent
                 
-                // Секция архива
-                archiveSection
+                // Убрали секцию архива, так как теперь переходим на отдельный экран
             }
         }
         .scrollIndicators(.visible)
         .contentShape(Rectangle()) // Добавляем contentShape для всего ScrollView
         .coordinateSpace(name: "scrollView") // Добавляем координатное пространство для лучшего скроллинга
-        .refreshable {
-            // This provides native pull-to-refresh behavior
-            if !archivedDebts.isEmpty {
-                withAnimation(.easeInOut(duration: 0.3)) {
-                    showingArchive = true
-                }
-            }
-        }
+        // Убрали pull-to-refresh для архива
     }
     
     private var headerView: some View {
@@ -235,31 +227,30 @@ struct DebtListView: View {
         .contentShape(Rectangle()) // Добавляем contentShape для лучшего скроллинга
     }
     
+    // Новый NavigationLink к экрану архива
     @ViewBuilder
-    private var archiveIndicatorView: some View {
+    private var archiveNavigationLinkView: some View {
         if !archivedDebts.isEmpty {
-            HStack {
-                Spacer()
-                VStack(spacing: 4) {
-                    Text("Архив (\(archivedDebts.count))")
-                        .font(.system(size: 12))
-                        .foregroundColor(themeManager.secondaryTextColor)
-                    
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 12))
-                        .foregroundColor(themeManager.secondaryTextColor)
-                        .rotationEffect(.degrees(showingArchive ? 180 : 0))
-                        .animation(.easeInOut(duration: 0.3), value: showingArchive)
+            NavigationLink {
+                ArchivedDebtsView()
+                    .environmentObject(debtStore)
+                    .environmentObject(themeManager)
+            } label: {
+                HStack {
+                    Spacer()
+                    VStack(spacing: 4) {
+                        Text("Архив (\(archivedDebts.count))")
+                            .font(.system(size: 12))
+                            .foregroundColor(themeManager.secondaryTextColor)
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 12))
+                            .foregroundColor(themeManager.secondaryTextColor)
+                    }
+                    Spacer()
                 }
-                Spacer()
+                .padding(.horizontal)
             }
-            .padding(.horizontal)
-            .contentShape(Rectangle()) // Добавляем contentShape для лучшего скроллинга
-            .onTapGesture {
-                withAnimation(.easeInOut(duration: 0.3)) {
-                    showingArchive = true
-                }
-            }
+            .buttonStyle(PlainButtonStyle())
         }
     }
     


### PR DESCRIPTION
Move archived debts from inline section to a dedicated screen to declutter the main view.

---
<a href="https://cursor.com/background-agent?bcId=bc-6dff662f-4a5b-45db-834b-4f72ea2bd49e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6dff662f-4a5b-45db-834b-4f72ea2bd49e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

