### PR TITLE
Fix debt repayment payment error

### DIFF
--- a/DebtNet/DebtListView.swift
+++ b/DebtNet/DebtListView.swift
@@ -648,6 +648,7 @@ struct DebtHistoryRowView: View {
         .sheet(isPresented: $showingDetail) {
             DebtDetailView(debt: debt)
                 .environmentObject(themeManager)
+                .environmentObject(debtStore)
         }
     }
 }
@@ -921,6 +922,7 @@ struct ArchivedDebtRowView: View {
         .sheet(isPresented: $showingDetail) {
             DebtDetailView(debt: debt)
                 .environmentObject(themeManager)
+                .environmentObject(debtStore)
         }
     }
 }


### PR DESCRIPTION
Pass `debtStore` as an environment object to `DebtDetailView` to prevent crashes when opening debt details or adding payments.

---
<a href="https://cursor.com/background-agent?bcId=bc-5064b594-91d2-4402-813c-0898b2a73e7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5064b594-91d2-4402-813c-0898b2a73e7c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

