### PR TITLE
Fix payment addition error for bottom debts

### DIFF
--- a/DebtNet/AddPaymentView.swift
+++ b/DebtNet/AddPaymentView.swift
@@ -10,6 +10,7 @@ struct AddPaymentView: View {
     @State private var paymentText: String = ""
     @State private var showAlert: Bool = false
     @State private var alertMessage: String = ""
+    @FocusState private var isTextFieldFocused: Bool
     
     private var paymentAmount: Double {
         Double(paymentText.replacingOccurrences(of: ",", with: ".")) ?? 0
@@ -27,6 +28,7 @@ struct AddPaymentView: View {
                         TextField("0", text: $paymentText)
                             .keyboardType(.decimalPad)
                             .textFieldStyle(ThemedTextFieldStyle())
+                            .focused($isTextFieldFocused)
                         
                         Text("₽")
                             .foregroundColor(themeManager.secondaryTextColor)
@@ -40,9 +42,11 @@ struct AddPaymentView: View {
             .background(themeManager.backgroundColor.ignoresSafeArea())
             .navigationBarItems(
                 leading: Button("Отмена") {
+                    isTextFieldFocused = false
                     presentationMode.wrappedValue.dismiss()
                 },
                 trailing: Button("Готово") {
+                    isTextFieldFocused = false
                     addPayment()
                 }
                 .disabled(!isValid)

--- a/DebtNet/DebtDetailView.swift
+++ b/DebtNet/DebtDetailView.swift
@@ -78,6 +78,7 @@ struct DebtDetailView: View {
             AddPaymentView(debt: debt)
                 .environmentObject(debtStore)
                 .environmentObject(themeManager)
+                .interactiveDismissDisabled(true)
         }
     }
     


### PR DESCRIPTION
Fixes `CHHapticEngine` errors and unexpected navigation when adding partial payments.

The issue occurred when the keyboard was dismissed simultaneously with the payment sheet, leading to a `CHHapticEngine` error and an unexpected UI bounce that redirected the user. This PR resolves it by explicitly dismissing the keyboard before closing the sheet and disabling interactive sheet dismissal.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f05e7fa-65ed-453d-9c73-596442f74d23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f05e7fa-65ed-453d-9c73-596442f74d23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

