### PR TITLE
Fixing code errors

### DIFF
--- a/DebtNet/DebtListView.swift
+++ b/DebtNet/DebtListView.swift
@@ -63,7 +63,7 @@ struct DebtListView: View {
                 .environmentObject(themeManager)
         }
         .onAppear { updateVisibleDebts() }
-        .onChange(of: selectedFilter) { _ in updateVisibleDebts() }
+        .onChange(of: selectedFilter) { updateVisibleDebts() }
         .onReceive(debtStore.$debts) { _ in updateVisibleDebts() }
 
     }


### PR DESCRIPTION
Update `onChange` modifier to use iOS 17 API and remove deprecation warning.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0605f75-5cfe-4aa4-80e5-ecbf53641298">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a0605f75-5cfe-4aa4-80e5-ecbf53641298">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

