### PR TITLE
Update buttons to iOS 26 style

### DIFF
--- a/DebtNet/DebtDetailView.swift
+++ b/DebtNet/DebtDetailView.swift
@@ -289,14 +289,8 @@ struct DebtDetailView: View {
                         Text("Добавить платеж")
                             .font(.system(size: 16, weight: .medium))
                     }
-                    .foregroundColor(.white)
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(
-                        RoundedRectangle(cornerRadius: 12)
-                            .fill(Color.blue)
-                    )
                 }
+                .buttonStyle(.ios26Filled)
             }
             
             // Mark as paid/unpaid button
@@ -306,18 +300,11 @@ struct DebtDetailView: View {
                 HStack {
                     Image(systemName: currentDebt.isPaid ? "arrow.uturn.left.circle" : "checkmark.circle")
                         .font(.system(size: 20))
-                    
                     Text(currentDebt.isPaid ? "Вернуть в активные" : "Отметить как погашенный")
                         .font(.system(size: 16, weight: .medium))
                 }
-                .foregroundColor(.white)
-                .frame(maxWidth: .infinity)
-                .padding()
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(currentDebt.isPaid ? Color.orange : Color.green)
-                )
             }
+            .buttonStyle(IOS26FilledColorButtonStyle(background: currentDebt.isPaid ? Color.orange : Color.green))
             
             // Delete button
             Button(action: {
@@ -326,18 +313,11 @@ struct DebtDetailView: View {
                 HStack {
                     Image(systemName: "trash")
                         .font(.system(size: 20))
-                    
                     Text("Удалить долг")
                         .font(.system(size: 16, weight: .medium))
                 }
-                .foregroundColor(.white)
-                .frame(maxWidth: .infinity)
-                .padding()
-                .background(
-                    RoundedRectangle(cornerRadius: 12)
-                        .fill(Color.red)
-                )
             }
+            .buttonStyle(.ios26Destructive)
         }
     }
 
@@ -448,26 +428,14 @@ struct PaymentInputAlert: View {
                     Button(action: onCancel) {
                         Text("Отмена")
                             .font(.system(size: 16, weight: .medium))
-                            .frame(maxWidth: .infinity)
-                            .padding()
-                            .background(
-                                RoundedRectangle(cornerRadius: 12)
-                                    .fill(themeManager.cardSecondaryBackgroundColor)
-                            )
                     }
-                    .foregroundColor(themeManager.primaryTextColor)
+                    .buttonStyle(.ios26Bordered(foreground: themeManager.primaryTextColor))
                     
                     Button(action: onConfirm) {
                         Text("Добавить")
                             .font(.system(size: 16, weight: .semibold))
-                            .frame(maxWidth: .infinity)
-                            .padding()
-                            .background(
-                                RoundedRectangle(cornerRadius: 12)
-                                    .fill(Color.blue)
-                            )
                     }
-                    .foregroundColor(.white)
+                    .buttonStyle(.ios26Filled)
                     .disabled(!isValid)
                     .opacity(isValid ? 1.0 : 0.6)
                 }

--- a/DebtNet/DebtListView.swift
+++ b/DebtNet/DebtListView.swift
@@ -116,16 +116,12 @@ struct DebtListView: View {
                 showingNotificationSettings = true
             }) {
                 ZStack {
-                    // Blue circular background
                     Circle()
                         .fill(Color.blue)
                         .frame(width: 40, height: 40)
-                    
                     Image(systemName: notificationManager.isNotificationEnabled ? "bell.fill" : "bell")
                         .foregroundColor(.white)
                         .font(.system(size: 18, weight: .medium))
-                    
-                    // Badge for pending notifications
                     if notificationManager.isNotificationEnabled && upcomingDebtsCount > 0 {
                         Text("\(upcomingDebtsCount)")
                             .font(.caption2)
@@ -160,16 +156,8 @@ struct DebtListView: View {
                     selectedFilter = option
                 }) {
                     Text(option.rawValue)
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundColor(selectedFilter == option ? .white : themeManager.secondaryTextColor)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 8)
-                        .background(
-                            RoundedRectangle(cornerRadius: 20)
-                                .fill(selectedFilter == option ? Color.red : themeManager.cardBackgroundColor)
-                                .shadow(color: selectedFilter == option ? Color.red.opacity(0.4) : themeManager.shadowColor, radius: selectedFilter == option ? 6 : 1, x: 0, y: selectedFilter == option ? 2 : 1)
-                        )
                 }
+                .buttonStyle(IOS26CapsuleToggleStyle(isSelected: selectedFilter == option, selectedColor: option == .owedToMe ? .green : option == .iOwe ? .red : .gray))
             }
             Spacer()
         }
@@ -258,7 +246,7 @@ struct DebtListView: View {
                 }
                 .padding(.horizontal)
             }
-            .buttonStyle(PlainButtonStyle())
+            .buttonStyle(.plain)
         }
     }
     
@@ -525,7 +513,7 @@ struct DebtHistoryRowView: View {
                             .frame(width: 26, height: 26)
                     )
             }
-            .buttonStyle(PlainButtonStyle())
+            .buttonStyle(.plain)
         }
     }
     
@@ -767,7 +755,7 @@ struct ArchivedDebtRowView: View {
                     .foregroundColor(.orange)
                     .font(.system(size: 20))
             }
-            .buttonStyle(PlainButtonStyle())
+            .buttonStyle(.plain)
         }
     }
     

--- a/DebtNet/IOS26ButtonStyle.swift
+++ b/DebtNet/IOS26ButtonStyle.swift
@@ -1,0 +1,158 @@
+import SwiftUI
+
+struct IOS26FilledButtonStyle: ButtonStyle {
+    @EnvironmentObject var themeManager: ThemeManager
+    var cornerRadius: CGFloat = 12
+    var minHeight: CGFloat = 44
+    
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundColor(themeManager.primaryButtonForeground)
+            .frame(maxWidth: .infinity, minHeight: minHeight)
+            .padding(.horizontal, 12)
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(themeManager.primaryButtonBackground)
+            )
+            .opacity(configuration.isPressed ? 0.85 : 1.0)
+            .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
+            .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
+    }
+}
+
+struct IOS26TintedButtonStyle: ButtonStyle {
+    @EnvironmentObject var themeManager: ThemeManager
+    var cornerRadius: CGFloat = 12
+    var minHeight: CGFloat = 44
+    
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundColor(themeManager.secondaryButtonForeground)
+            .frame(maxWidth: .infinity, minHeight: minHeight)
+            .padding(.horizontal, 12)
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(themeManager.secondaryButtonBackground)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .stroke(themeManager.tintedButtonBorder, lineWidth: 0.5)
+            )
+            .opacity(configuration.isPressed ? 0.85 : 1.0)
+            .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
+            .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
+    }
+}
+
+struct IOS26DestructiveButtonStyle: ButtonStyle {
+    @EnvironmentObject var themeManager: ThemeManager
+    var cornerRadius: CGFloat = 12
+    var minHeight: CGFloat = 44
+    
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundColor(themeManager.destructiveButtonForeground)
+            .frame(maxWidth: .infinity, minHeight: minHeight)
+            .padding(.horizontal, 12)
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(themeManager.destructiveButtonBackground)
+            )
+            .opacity(configuration.isPressed ? 0.85 : 1.0)
+            .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
+            .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
+    }
+}
+
+struct IOS26BorderedButtonStyle: ButtonStyle {
+    @EnvironmentObject var themeManager: ThemeManager
+    var cornerRadius: CGFloat = 12
+    var minHeight: CGFloat = 36
+    var foreground: Color? = nil
+    
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 14, weight: .medium))
+            .foregroundColor(foreground ?? themeManager.primaryTextColor)
+            .padding(.horizontal, 12)
+            .frame(minHeight: minHeight)
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(themeManager.subtleButtonBackground)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .stroke(themeManager.separatorColor, lineWidth: 0.5)
+            )
+            .opacity(configuration.isPressed ? 0.85 : 1.0)
+            .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
+            .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
+    }
+}
+
+struct IOS26CapsuleToggleStyle: ButtonStyle {
+    let isSelected: Bool
+    var selectedColor: Color
+    @EnvironmentObject var themeManager: ThemeManager
+    
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 14, weight: .medium))
+            .foregroundColor(isSelected ? .white : themeManager.secondaryTextColor)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(
+                Capsule()
+                    .fill(isSelected ? selectedColor : themeManager.cardBackgroundColor)
+            )
+            .shadow(color: isSelected ? selectedColor.opacity(0.4) : themeManager.shadowColor, radius: isSelected ? 6 : 1, x: 0, y: isSelected ? 2 : 1)
+            .opacity(configuration.isPressed ? 0.9 : 1.0)
+            .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
+            .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
+    }
+}
+
+extension ButtonStyle where Self == IOS26FilledButtonStyle {
+    static var ios26Filled: IOS26FilledButtonStyle { IOS26FilledButtonStyle() }
+}
+
+extension ButtonStyle where Self == IOS26TintedButtonStyle {
+    static var ios26Tinted: IOS26TintedButtonStyle { IOS26TintedButtonStyle() }
+}
+
+extension ButtonStyle where Self == IOS26DestructiveButtonStyle {
+    static var ios26Destructive: IOS26DestructiveButtonStyle { IOS26DestructiveButtonStyle() }
+}
+
+extension ButtonStyle where Self == IOS26BorderedButtonStyle {
+    static func ios26Bordered(foreground: Color? = nil) -> IOS26BorderedButtonStyle {
+        IOS26BorderedButtonStyle(foreground: foreground)
+    }
+}
+
+// Color-customizable filled style
+struct IOS26FilledColorButtonStyle: ButtonStyle {
+    var background: Color
+    var foreground: Color = .white
+    var cornerRadius: CGFloat = 12
+    var minHeight: CGFloat = 44
+    
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundColor(foreground)
+            .frame(maxWidth: .infinity, minHeight: minHeight)
+            .padding(.horizontal, 12)
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(background)
+            )
+            .opacity(configuration.isPressed ? 0.85 : 1.0)
+            .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
+            .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
+    }
+}
+

--- a/DebtNet/StatisticsView.swift
+++ b/DebtNet/StatisticsView.swift
@@ -184,7 +184,7 @@ struct StatCard: View {
             .scaleEffect(isActive ? 0.95 : 1.0)
             .animation(.easeInOut(duration: 0.2), value: isActive)
         }
-        .buttonStyle(PlainButtonStyle())
+        .buttonStyle(.plain)
     }
     
     private var formattedValue: String {
@@ -340,8 +340,7 @@ struct FilteredDebtRow: View {
                             debtStore.markAsPaid(debt)
                         }
                     }
-                    .font(.system(size: 12))
-                    .foregroundColor(.blue)
+                    .buttonStyle(.ios26Bordered(foreground: .blue))
                 } else {
                     Text("Погашен")
                         .font(.system(size: 12))
@@ -748,8 +747,7 @@ struct OverdueDebtRow: View {
                         debtStore.markAsPaid(debt)
                     }
                 }
-                .font(.system(size: 12))
-                .foregroundColor(.blue)
+                .buttonStyle(.ios26Bordered(foreground: .blue))
             }
         }
         .padding(.vertical, 4)

--- a/DebtNet/ThemeManager.swift
+++ b/DebtNet/ThemeManager.swift
@@ -79,6 +79,30 @@ class ThemeManager: ObservableObject {
         isDarkMode ? .blue.opacity(0.8) : .blue
     }
     
+    // iOS-style button tokens
+    var primaryButtonBackground: Color {
+        isDarkMode ? Color(red: 0.12, green: 0.42, blue: 0.95) : Color.blue
+    }
+    var primaryButtonForeground: Color { .white }
+    
+    var secondaryButtonBackground: Color {
+        isDarkMode ? Color.blue.opacity(0.18) : Color.blue.opacity(0.12)
+    }
+    var secondaryButtonForeground: Color {
+        isDarkMode ? Color(red: 0.7, green: 0.85, blue: 1.0) : Color.blue
+    }
+    
+    var destructiveButtonBackground: Color { Color.red }
+    var destructiveButtonForeground: Color { .white }
+    
+    var tintedButtonBorder: Color {
+        isDarkMode ? Color.gray.opacity(0.4) : Color.gray.opacity(0.3)
+    }
+    
+    var subtleButtonBackground: Color {
+        isDarkMode ? Color.white.opacity(0.06) : Color.black.opacity(0.04)
+    }
+    
     var successColor: Color {
         isDarkMode ? .green.opacity(0.8) : .green
     }


### PR DESCRIPTION
Implement and apply a new iOS 26-style button system across the app for a consistent UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-06258d48-f86d-4a3e-ac75-e4b91133a7a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-06258d48-f86d-4a3e-ac75-e4b91133a7a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds reusable iOS 26 button styles and tokens, and updates DebtDetail, DebtList, and Statistics screens to use them.
> 
> - **UI/Button System**:
>   - Add `IOS26ButtonStyle.swift` with reusable styles: `IOS26FilledButtonStyle`, `IOS26TintedButtonStyle`, `IOS26DestructiveButtonStyle`, `IOS26BorderedButtonStyle`, `IOS26CapsuleToggleStyle`, and `IOS26FilledColorButtonStyle`, plus convenience `.ios26*` extensions.
>   - Update `ThemeManager` with button color tokens (`primaryButtonBackground/Foreground`, `secondary*`, `destructive*`, `tintedButtonBorder`, `subtleButtonBackground`).
> - **View Updates**:
>   - `DebtDetailView`: replace manual button styling with `.ios26Filled`, `IOS26FilledColorButtonStyle(background: ...)`, and `.ios26Destructive`; `PaymentInputAlert` uses `.ios26Bordered(...)` and `.ios26Filled`.
>   - `DebtListView`: filter chips use `IOS26CapsuleToggleStyle(isSelected:selectedColor:)`; multiple buttons standardized to `.buttonStyle(.plain)`.
>   - `StatisticsView`: action "Погасить" buttons use `.ios26Bordered(foreground: .blue)`; card buttons use `.buttonStyle(.plain)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d51b1ce551853091fd70f1d17474ff6c606ebb4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->